### PR TITLE
conn.salt contain "\0" not match the protocal specification 

### DIFF
--- a/mysql/util.go
+++ b/mysql/util.go
@@ -52,6 +52,12 @@ func RandomBuf(size int) ([]byte, error) {
 		return nil, err
 	}
 
+	// avoid to generate '\0'
+	for i, b := range buf {
+		if uint8(b) == 0 {
+			buf[i] = '0'
+		}
+	}
 	return buf, nil
 }
 


### PR DESCRIPTION
http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeV10

defines the "string[8]      auth-plugin-data-part-1"

so if proxy.Conn.salt contains the "\0" character, some tools(sysbench, wireshark) can't parse the packet correctly.

![qq 20141205145418](https://cloud.githubusercontent.com/assets/1264866/5312147/eb94b3da-7c8e-11e4-92f7-bb70eb1b6a6a.jpg)
